### PR TITLE
Add inline exclusion/policy matching helpers (#724)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `clear_retention_config` methods on `Store` for managing the retention
   period. Added `purge_old_column_stats` method to `Store` that deletes column
   statistics older than the configured retention period.
+- Added `Event::matches_exclusion` and `Event::score_against_policies` public
+  helpers so callers can perform inline triage exclusion matching and inline
+  policy scoring without going through the full `Event::matches` filter
+  pipeline. `score_against_policies` sums only `score_by_attr +
+  score_by_confidence` and assumes exclusions have already been applied by the
+  caller; policies whose `response` is empty contribute no score.
 
 ### Changed
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -84,7 +84,7 @@ pub use self::{
     unusual_destination_pattern::{UnusualDestinationPattern, UnusualDestinationPatternFields},
 };
 use super::{
-    Customer, EventCategory, Network, TriagePolicyInput,
+    Customer, EventCategory, Network, TriageExclusion, TriagePolicyInput,
     types::{Endpoint, HostNetworkGroup},
 };
 
@@ -561,6 +561,127 @@ impl Event {
             Event::ExtraThreat(event) => event.matches(locator, filter),
             Event::LockyRansomware(event) => event.matches(locator, filter),
             Event::SuspiciousTlsTraffic(event) => event.matches(locator, filter),
+        }
+    }
+
+    /// Returns whether any of `exclusions` matches this event.
+    ///
+    /// Dispatches through each event variant's `score_by_triage_exclusion`
+    /// override so per-event semantics (DNS domain/hostname, HTTP URI/host,
+    /// Tor domain, etc.) are preserved. The default implementation handles
+    /// the `IpAddress` variant only; richer exclusion shapes for events
+    /// without an override are not currently matched.
+    #[must_use]
+    pub fn matches_exclusion(&self, exclusions: &[TriageExclusion]) -> bool {
+        match self {
+            Event::DnsCovertChannel(event) => event.matched_any_exclusion(exclusions),
+            Event::HttpThreat(event) => event.matched_any_exclusion(exclusions),
+            Event::RdpBruteForce(event) => event.matched_any_exclusion(exclusions),
+            Event::RepeatedHttpSessions(event) => event.matched_any_exclusion(exclusions),
+            Event::TorConnection(event) => event.matched_any_exclusion(exclusions),
+            Event::TorConnectionConn(event) => event.matched_any_exclusion(exclusions),
+            Event::DomainGenerationAlgorithm(event) => event.matched_any_exclusion(exclusions),
+            Event::FtpBruteForce(event) => event.matched_any_exclusion(exclusions),
+            Event::FtpPlainText(event) => event.matched_any_exclusion(exclusions),
+            Event::PortScan(event) => event.matched_any_exclusion(exclusions),
+            Event::MultiHostPortScan(event) => event.matched_any_exclusion(exclusions),
+            Event::ExternalDdos(event) => event.matched_any_exclusion(exclusions),
+            Event::NonBrowser(event) => event.matched_any_exclusion(exclusions),
+            Event::LdapBruteForce(event) => event.matched_any_exclusion(exclusions),
+            Event::LdapPlainText(event) => event.matched_any_exclusion(exclusions),
+            Event::CryptocurrencyMiningPool(event) => event.matched_any_exclusion(exclusions),
+            Event::Blocklist(record_type) => match record_type {
+                RecordType::Bootp(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Conn(event) => event.matched_any_exclusion(exclusions),
+                RecordType::DceRpc(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Dhcp(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Dns(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Ftp(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Http(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Kerberos(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Ldap(event) => event.matched_any_exclusion(exclusions),
+                RecordType::MalformedDns(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Mqtt(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Nfs(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Ntlm(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Radius(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Rdp(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Smb(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Smtp(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Ssh(event) => event.matched_any_exclusion(exclusions),
+                RecordType::Tls(event) => event.matched_any_exclusion(exclusions),
+                RecordType::UnusualDestinationPattern(event) => {
+                    event.matched_any_exclusion(exclusions)
+                }
+            },
+            Event::WindowsThreat(event) => event.matched_any_exclusion(exclusions),
+            Event::NetworkThreat(event) => event.matched_any_exclusion(exclusions),
+            Event::ExtraThreat(event) => event.matched_any_exclusion(exclusions),
+            Event::LockyRansomware(event) => event.matched_any_exclusion(exclusions),
+            Event::SuspiciousTlsTraffic(event) => event.matched_any_exclusion(exclusions),
+        }
+    }
+
+    /// Computes inline triage scores for this event against each of `policies`.
+    ///
+    /// Each policy contributes a `TriageScore` only when
+    /// `score_by_attr + score_by_confidence` reaches at least one of the
+    /// policy's `response.minimum_score` thresholds; policies whose
+    /// `response` is empty contribute nothing. Each policy's
+    /// `triage_exclusion` is treated as already applied by the caller and
+    /// must be empty (asserted in debug builds).
+    #[must_use]
+    pub fn score_against_policies(&self, policies: &[TriagePolicyInput]) -> Vec<TriageScore> {
+        match self {
+            Event::DnsCovertChannel(event) => event.inline_scores_against_policies(policies),
+            Event::HttpThreat(event) => event.inline_scores_against_policies(policies),
+            Event::RdpBruteForce(event) => event.inline_scores_against_policies(policies),
+            Event::RepeatedHttpSessions(event) => event.inline_scores_against_policies(policies),
+            Event::TorConnection(event) => event.inline_scores_against_policies(policies),
+            Event::TorConnectionConn(event) => event.inline_scores_against_policies(policies),
+            Event::DomainGenerationAlgorithm(event) => {
+                event.inline_scores_against_policies(policies)
+            }
+            Event::FtpBruteForce(event) => event.inline_scores_against_policies(policies),
+            Event::FtpPlainText(event) => event.inline_scores_against_policies(policies),
+            Event::PortScan(event) => event.inline_scores_against_policies(policies),
+            Event::MultiHostPortScan(event) => event.inline_scores_against_policies(policies),
+            Event::ExternalDdos(event) => event.inline_scores_against_policies(policies),
+            Event::NonBrowser(event) => event.inline_scores_against_policies(policies),
+            Event::LdapBruteForce(event) => event.inline_scores_against_policies(policies),
+            Event::LdapPlainText(event) => event.inline_scores_against_policies(policies),
+            Event::CryptocurrencyMiningPool(event) => {
+                event.inline_scores_against_policies(policies)
+            }
+            Event::Blocklist(record_type) => match record_type {
+                RecordType::Bootp(event) => event.inline_scores_against_policies(policies),
+                RecordType::Conn(event) => event.inline_scores_against_policies(policies),
+                RecordType::DceRpc(event) => event.inline_scores_against_policies(policies),
+                RecordType::Dhcp(event) => event.inline_scores_against_policies(policies),
+                RecordType::Dns(event) => event.inline_scores_against_policies(policies),
+                RecordType::Ftp(event) => event.inline_scores_against_policies(policies),
+                RecordType::Http(event) => event.inline_scores_against_policies(policies),
+                RecordType::Kerberos(event) => event.inline_scores_against_policies(policies),
+                RecordType::Ldap(event) => event.inline_scores_against_policies(policies),
+                RecordType::MalformedDns(event) => event.inline_scores_against_policies(policies),
+                RecordType::Mqtt(event) => event.inline_scores_against_policies(policies),
+                RecordType::Nfs(event) => event.inline_scores_against_policies(policies),
+                RecordType::Ntlm(event) => event.inline_scores_against_policies(policies),
+                RecordType::Radius(event) => event.inline_scores_against_policies(policies),
+                RecordType::Rdp(event) => event.inline_scores_against_policies(policies),
+                RecordType::Smb(event) => event.inline_scores_against_policies(policies),
+                RecordType::Smtp(event) => event.inline_scores_against_policies(policies),
+                RecordType::Ssh(event) => event.inline_scores_against_policies(policies),
+                RecordType::Tls(event) => event.inline_scores_against_policies(policies),
+                RecordType::UnusualDestinationPattern(event) => {
+                    event.inline_scores_against_policies(policies)
+                }
+            },
+            Event::WindowsThreat(event) => event.inline_scores_against_policies(policies),
+            Event::NetworkThreat(event) => event.inline_scores_against_policies(policies),
+            Event::ExtraThreat(event) => event.inline_scores_against_policies(policies),
+            Event::LockyRansomware(event) => event.inline_scores_against_policies(policies),
+            Event::SuspiciousTlsTraffic(event) => event.inline_scores_against_policies(policies),
         }
     }
 

--- a/src/event/common.rs
+++ b/src/event/common.rs
@@ -14,7 +14,9 @@ use super::{
     EventCategory, EventFilter, FlowKind, LearningMethod, ThreatLevel, TrafficDirection,
     eq_ip_country,
 };
-use crate::{AttrCmpKind, Confidence, PacketAttr, TriageExclusion, ValueKind};
+use crate::{
+    AttrCmpKind, Confidence, PacketAttr, Response, TriageExclusion, TriagePolicyInput, ValueKind,
+};
 
 /// Epsilon value for inclusive confidence comparisons
 const CONFIDENCE_EPSILON: f32 = 1e-6;
@@ -254,14 +256,7 @@ pub(super) trait Match {
                     let score = self.score_by_triage_exclusion(&triage.triage_exclusion)
                         + self.score_by_attr(&triage.packet_attr)
                         + self.score_by_confidence(&triage.confidence);
-                    if triage.response.iter().any(|r| score >= r.minimum_score) {
-                        Some(TriageScore {
-                            policy_id: triage.id,
-                            score,
-                        })
-                    } else {
-                        None
-                    }
+                    self.build_triage_score(triage.id, score, &triage.response)
                 })
                 .collect::<Vec<_>>();
             if triage_scores.is_empty() {
@@ -283,6 +278,58 @@ pub(super) trait Match {
             }
         });
         if matched { f64::MIN } else { 0.0 }
+    }
+
+    /// Returns whether any of `exclusions` matches this event.
+    ///
+    /// Hides the `f64::MIN` sentinel returned by `score_by_triage_exclusion`
+    /// so callers don't have to know that internal contract.
+    fn matched_any_exclusion(&self, exclusions: &[TriageExclusion]) -> bool {
+        // `score_by_triage_exclusion` returns the bit-exact constant `f64::MIN`
+        // as a sentinel; this is a deliberate equality check, not an
+        // approximate comparison.
+        #[allow(clippy::float_cmp)]
+        {
+            self.score_by_triage_exclusion(exclusions) == f64::MIN
+        }
+    }
+
+    /// Builds a `TriageScore` if `score` reaches at least one threshold in
+    /// `response`. Returns `None` when `response` is empty or when no
+    /// threshold is met.
+    fn build_triage_score(
+        &self,
+        policy_id: u32,
+        score: f64,
+        response: &[Response],
+    ) -> Option<TriageScore> {
+        if response.iter().any(|r| score >= r.minimum_score) {
+            Some(TriageScore { policy_id, score })
+        } else {
+            None
+        }
+    }
+
+    /// Computes inline triage scores for `policies`, treating each policy's
+    /// `triage_exclusion` as already applied by the caller.
+    ///
+    /// Each policy contributes a `TriageScore` only when
+    /// `score_by_attr + score_by_confidence` reaches at least one
+    /// `response.minimum_score` threshold. Policies whose `response` is
+    /// empty contribute no score.
+    fn inline_scores_against_policies(&self, policies: &[TriagePolicyInput]) -> Vec<TriageScore> {
+        policies
+            .iter()
+            .filter_map(|p| {
+                debug_assert!(
+                    p.triage_exclusion.is_empty(),
+                    "inline scoring expects exclusions to have been applied by the caller"
+                );
+                let score =
+                    self.score_by_attr(&p.packet_attr) + self.score_by_confidence(&p.confidence);
+                self.build_triage_score(p.id, score, &p.response)
+            })
+            .collect()
     }
 
     fn score_by_confidence(&self, confidence: &[Confidence]) -> f64 {
@@ -2793,5 +2840,155 @@ mod tests {
                 .partial_cmp(&0.0),
             Some(Ordering::Equal)
         );
+    }
+
+    fn dns_covert_channel_event() -> Event {
+        let time = Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap();
+        Event::DnsCovertChannel(DnsCovertChannel::new(time, dns_event_fields()))
+    }
+
+    fn blocklist_http_event() -> Event {
+        let time = Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap();
+        Event::Blocklist(RecordType::Http(BlocklistHttp::new(
+            time,
+            blocklist_http_fields(),
+        )))
+    }
+
+    fn confidence_for_dns_covert_channel(weight: f64) -> crate::Confidence {
+        make_confidence(
+            Some(EventCategory::CommandAndControl),
+            "dns covert channel",
+            0.0,
+            Some(weight),
+        )
+    }
+
+    fn make_policy(
+        id: u32,
+        confidence: Vec<crate::Confidence>,
+        response: Vec<crate::Response>,
+    ) -> crate::TriagePolicyInput {
+        crate::TriagePolicyInput {
+            id,
+            name: format!("policy-{id}"),
+            creation_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap(),
+            triage_exclusion: Vec::new(),
+            packet_attr: Vec::new(),
+            confidence,
+            response,
+        }
+    }
+
+    fn make_response(minimum_score: f64) -> crate::Response {
+        crate::Response {
+            minimum_score,
+            kind: crate::ResponseKind::Manual,
+        }
+    }
+
+    #[test]
+    fn matches_exclusion_dns_covert_channel_match_and_non_match() {
+        let event = dns_covert_channel_event();
+
+        // dns_event_fields() uses query "foo.com"; the per-event override
+        // splits at the first dot, leaving "foo" as the hostname label.
+        let matching = vec![crate::TriageExclusion::Hostname(vec!["foo".to_string()])];
+        let non_matching = vec![crate::TriageExclusion::Hostname(vec![
+            "nomatch".to_string(),
+        ])];
+
+        assert!(event.matches_exclusion(&matching));
+        assert!(!event.matches_exclusion(&non_matching));
+        assert!(!event.matches_exclusion(&[]));
+    }
+
+    #[test]
+    fn matches_exclusion_blocklist_http_uri() {
+        let event = blocklist_http_event();
+
+        // blocklist_http_fields() uses uri "/uri/path".
+        let matching = vec![crate::TriageExclusion::Uri(vec!["/uri/path".to_string()])];
+        let non_matching = vec![crate::TriageExclusion::Uri(vec!["/other".to_string()])];
+
+        assert!(event.matches_exclusion(&matching));
+        assert!(!event.matches_exclusion(&non_matching));
+    }
+
+    #[test]
+    fn score_against_policies_empty_slice_returns_empty() {
+        let event = dns_covert_channel_event();
+        assert!(event.score_against_policies(&[]).is_empty());
+    }
+
+    #[test]
+    fn score_against_policies_only_passing_policy_returned() {
+        let event = dns_covert_channel_event();
+
+        // Both policies score weight=10 from confidence; the first
+        // policy's threshold is met, the second is not.
+        let passing = make_policy(
+            1,
+            vec![confidence_for_dns_covert_channel(10.0)],
+            vec![make_response(5.0)],
+        );
+        let failing = make_policy(
+            2,
+            vec![confidence_for_dns_covert_channel(10.0)],
+            vec![make_response(100.0)],
+        );
+
+        let scores = event.score_against_policies(&[passing, failing]);
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].policy_id, 1);
+        assert_eq!(scores[0].score.partial_cmp(&10.0), Some(Ordering::Equal));
+    }
+
+    #[test]
+    fn score_against_policies_empty_response_drops_score() {
+        let event = dns_covert_channel_event();
+
+        let policy = make_policy(
+            42,
+            vec![confidence_for_dns_covert_channel(10.0)],
+            Vec::new(),
+        );
+
+        assert!(event.score_against_policies(&[policy]).is_empty());
+    }
+
+    #[test]
+    fn legacy_matches_drops_event_when_no_policy_passes() {
+        let event = dns_covert_channel_event();
+
+        // The legacy formula sums score_by_triage_exclusion +
+        // score_by_attr + score_by_confidence and threshold-filters by
+        // response.minimum_score. None of the policies below should pass.
+        let unreachable_policy = make_policy(
+            1,
+            vec![confidence_for_dns_covert_channel(1.0)],
+            vec![make_response(1_000.0)],
+        );
+
+        let filter = EventFilter {
+            customers: None,
+            endpoints: None,
+            directions: None,
+            source: None,
+            destination: None,
+            countries: None,
+            categories: None,
+            levels: None,
+            kinds: None,
+            learning_methods: None,
+            sensors: None,
+            confidence_min: None,
+            confidence_max: None,
+            triage_policies: Some(vec![unreachable_policy]),
+        };
+
+        let (matched, scores) = event.matches(None, &filter).unwrap();
+        assert!(!matched);
+        assert!(scores.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Adds two public helpers on `Event` so `review-web`'s upcoming `eventListWithTriage` resolver can perform inline triage exclusion matching and inline policy scoring without widening the visibility of the internal `Match` trait:

- `Event::matches_exclusion(&[TriageExclusion]) -> bool` — dispatches through each event variant's `score_by_triage_exclusion` override (including the `Blocklist(RecordType)` sub-dispatch), preserving DNS/HTTP/Tor/etc. per-event semantics. The `f64::MIN` sentinel used internally by `score_by_triage_exclusion` is hidden behind a private `Match::matched_any_exclusion` helper so it does not leak into public code.
- `Event::score_against_policies(&[TriagePolicyInput]) -> Vec<TriageScore>` — sums only `score_by_attr + score_by_confidence` (the resolver is expected to apply exclusions in a prior step), then threshold-filters by `response.minimum_score`. A `debug_assert!` enforces that each input policy's `triage_exclusion` is empty. Policies with an empty `response` contribute no score, matching existing `other_matches` behavior.

Shared `TriageScore` construction (`Match::build_triage_score`) is factored out so the legacy and inline paths stay in sync without coupling their score formulas. The legacy `Match::other_matches` formula is unchanged. The `Match` trait's visibility is not widened; only the two new helpers on `Event` become public.

Closes #724

## Test plan

- [x] `matches_exclusion` matches and non-matches for a top-level variant (`DnsCovertChannel` via `Hostname`)
- [x] `matches_exclusion` exercises the `Blocklist(RecordType)` nested dispatch (`Blocklist::Http` via `Uri`)
- [x] `score_against_policies` with an empty `policies` slice returns an empty `Vec`
- [x] `score_against_policies` returns only the policies whose score reaches `minimum_score`
- [x] `score_against_policies` drops policies whose `response` is empty
- [x] Legacy regression: `Event::matches` still drops the event when no policy's score reaches `minimum_score` (guards the shared-helper refactor)
- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate`
- [x] `cargo clippy --bins --tests --all-features -- -D warnings`
- [x] `cargo test --all-features` (new event::common tests pass)
- [x] `markdownlint-cli2` on `CHANGELOG.md`