### PR TITLE
Bump version to 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.45.0] - 2026-05-09
 
 ### Added
 
@@ -1439,7 +1439,7 @@ AsRef<[u8]>`). This change accommodates scenarios where the information stored
 - Modified `FtpBruteForce` by adding an `is_internal` field which is a boolean
   indicating whether it is internal or not.
 
-[Unreleased]: https://github.com/aicers/review-database/compare/0.44.1...main
+[0.45.0]: https://github.com/aicers/review-database/compare/0.44.1...0.45.0
 [0.44.1]: https://github.com/aicers/review-database/compare/0.44.0...0.44.1
 [0.44.0]: https://github.com/aicers/review-database/compare/0.43.0...0.44.0
 [0.43.0]: https://github.com/aicers/review-database/compare/0.42.0...0.43.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.45.0-alpha.1"
+version = "0.45.0"
 edition = "2024"
 
 [dependencies]

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -106,7 +106,7 @@ use crate::{
 /// // release that involves database format change) to 3.5.0, including
 /// // all alpha changes finalized in 3.5.0.
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">=0.45.0-alpha.1,<0.45.0-alpha.2";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.45.0,<0.46.0-alpha";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///
@@ -165,8 +165,8 @@ pub fn migrate_data_dir<P: AsRef<Path>>(data_dir: P, backup_dir: P) -> Result<()
             migrate_0_43_to_0_44,
         ),
         (
-            VersionReq::parse(">=0.44.0,<0.45.0-alpha.1")?,
-            Version::parse("0.45.0-alpha.1")?,
+            VersionReq::parse(">=0.44.0,<0.45.0")?,
+            Version::parse("0.45.0")?,
             migrate_0_44_to_0_45,
         ),
     ];


### PR DESCRIPTION
## Summary

Promotes `0.45.0-alpha.1` to the `0.45.0` stable release.

- Bumps the package version in `Cargo.toml` from `0.45.0-alpha.1` to `0.45.0`.
- Stamps the `Unreleased` section of `CHANGELOG.md` as `[0.45.0] - 2026-05-09` and refreshes the comparison links.
- Widens `COMPATIBLE_VERSION_REQ` to `>=0.45.0,<0.46.0-alpha`.
- Updates the migration entry so that databases produced by any released `0.44.x` install migrate directly to `0.45.0` through the existing `migrate_0_44_to_0_45` (which converts `Confidence.threat_category` from `EventCategory` to `Option<EventCategory>`).

`0.45.0-alpha.1` is intentionally not a migration source, consistent with the project policy that prereleases are assumed incompatible with each other.

Closes #730

## Test plan

- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate`
- [x] `cargo clippy --bins --tests --all-features -- -D warnings`
- [x] `cargo test --all-features` (358 unit + 10 doc tests pass)
- [x] `markdownlint-cli2 CHANGELOG.md`