### PR TITLE
Skip the heavy CI jobs on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,23 @@
+# CHANGE FILTER: `changes` classifies the run's diff and the expensive jobs
+# gate on its `docs_only` output, so a pull request that only touches inert
+# documentation does not build and test the crate on two operating systems.
+# `markdown` is deliberately ungated — a docs-only change is exactly the change
+# that needs the Markdown lint to run.
+#
+# THE GATE IS FAIL-CLOSED. Each gated job's `if:` runs the job whenever the
+# filter did not positively report docs-only, including when the filter itself
+# failed. Without `!cancelled()` a failing `changes` would skip its dependants
+# instead, and GitHub counts a skipped required status check as a pass — so a
+# broken filter would wave an untested change through. Detection must fail red,
+# never open.
+#
+# `CI Gate` IS THE REQUIRED STATUS CHECK, not the individual jobs. A matrix job
+# skipped at the job level is never expanded, so a docs-only run reports `test`
+# rather than `test (ubuntu-latest)` — and a protection rule naming the
+# expanded contexts would wait forever for statuses that are never coming.
+# `CI Gate` always reports, under one stable name, and it also stops protection
+# from having to track matrix leg names at all.
+
 name: CI
 
 on: [push, pull_request]
@@ -6,8 +26,93 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    name: Change Filter
+    runs-on: ubuntu-latest
+    # Scoped to this job alone. `pull-requests: read` is what
+    # dorny/paths-filter needs to list a pull request's files; without it the
+    # job dies with "Resource not accessible by integration". Declaring the
+    # block here rather than at workflow level leaves every other job's token
+    # exactly as it is today.
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docs_only: ${{ steps.decide.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # a push diffs against its base commit locally
+
+      # A push carries its base in `github.event.before`. That sha is all-zeros
+      # on a branch's first push and can name a commit a force-push discarded,
+      # so establish that it is real and reachable before diffing. Leaving
+      # `sha` empty skips the filter below, which lands on docs_only=false.
+      - name: Resolve the push base
+        id: base
+        if: github.event_name != 'pull_request'
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [ -n "${BEFORE}" ] \
+            && [ "${BEFORE}" != '0000000000000000000000000000000000000000' ] \
+            && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null
+          then
+            echo "sha=${BEFORE}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Push base missing or unreachable; running the full suite."
+          fi
+
+      # On `pull_request` the action reads the file list from the API and
+      # ignores `base`; on `push` it diffs against the sha resolved above.
+      - name: Filter Paths
+        id: filter
+        if: github.event_name == 'pull_request' || steps.base.outputs.sha != ''
+        uses: dorny/paths-filter@v4
+        with:
+          base: ${{ steps.base.outputs.sha }}
+          filters: |
+            docs:
+              - "docs/**"
+              - "**/*.md"
+              - "LICENSE"
+              - ".markdownlint*"
+            code:
+              - "src/**"
+              - "tests/**"
+              - "Cargo.toml"
+              - ".clippy.toml"
+              - "diesel.toml"
+              - ".github/workflows/**"
+
+      # Docs-only requires a POSITIVE result on both halves: documentation
+      # touched, code untouched. A path in neither list leaves `docs` false and
+      # falls through here to the full suite, so a directory nobody thought to
+      # enumerate defaults to running everything rather than to running
+      # nothing. This is an allowlist of the inert, not a denylist.
+      - name: Decide Docs-Only
+        id: decide
+        run: |
+          if [ "${{ steps.filter.outputs.docs }}" = "true" ] \
+            && [ "${{ steps.filter.outputs.code }}" != "true" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  markdown:
+    name: Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v23
+
   check:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true') }}
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
@@ -18,11 +123,11 @@ jobs:
         run: cargo fmt -- --check --config group_imports=StdExternalCrate
       - name: Clippy
         run: cargo clippy --bins --tests --all-features -- -D warnings
-      - name: markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
 
   test:
     runs-on: ${{ matrix.os }}
+    needs: changes
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true') }}
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
@@ -37,6 +142,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true') }}
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
@@ -54,3 +161,40 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
+
+  # `always()`, deliberately, and not `!cancelled()`: a cancelled run would
+  # otherwise skip this job, and GitHub counts a skipped required check as a
+  # pass. Running through cancellation lets the assertions below see the
+  # cancelled results and report red.
+  gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    needs: [changes, markdown, check, test, coverage]
+    if: ${{ always() }}
+    steps:
+      # A filter that errored is a defect, not a tolerable outcome. The gated
+      # jobs did still run — their `if:` fails closed — but the breakage has to
+      # be visible rather than absorbed.
+      - name: Assert the change filter succeeded
+        if: ${{ needs.changes.result != 'success' }}
+        run: |
+          echo "Change Filter: ${{ needs.changes.result }}" >&2
+          exit 1
+
+      # `skipped` is a pass here, and only here: it is what a gated job reports
+      # on a docs-only change. `cancelled` is not.
+      - name: Assert every job passed or was skipped
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "${RESULTS}"
+          bad="$(printf '%s' "${RESULTS}" \
+            | jq -r 'to_entries[]
+                     | select(.value.result != "success" and .value.result != "skipped")
+                     | "  \(.key): \(.value.result)"')"
+          if [ -n "${bad}" ]; then
+            echo "Not green:" >&2
+            echo "${bad}" >&2
+            exit 1
+          fi


### PR DESCRIPTION
Closes #832.

A pull request that changed nothing but Markdown ran the whole suite: on #820, eight check runs, every one of them building and testing the crate, half of them on macOS.

## What changed

`.github/workflows/ci.yml`, and nothing else.

- **`Change Filter`** (`dorny/paths-filter@v4`) classifies the diff and publishes a `docs_only` output, following the shape `aicers/aice-web-next` and `aicers/bootroot` already use. `pull-requests: read` is scoped to that one job, so no other job's token changes.
- **`Markdown`** is lifted out of `check` into its own ungated job. It had been sharing a job with clippy and the format check, so gating `check` would have taken the Markdown lint down with it — and a docs-only change is exactly the change that needs it.
- **`check`, `test`, `coverage`** gate on the filter, fail-closed.
- **`CI Gate`** is new: an always-run aggregator that becomes the single required status check. See the follow-up section.

## Fail-closed, deliberately

`aicers/bootler` rejected the filter-job shape on the grounds that a failing filter skips its dependants and GitHub counts a skipped required check as a pass, so a broken filter would wave an untested change through. The condition answers that directly:

```yaml
if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true') }}
```

`!cancelled()` keeps each gated job running whenever the filter did not *positively* report docs-only — a failed filter included. `CI Gate` additionally holds `changes` to `success`, so a filter that breaks is red rather than merely harmless.

Classification is an allowlist of the inert, not a denylist. A path in neither list leaves `docs` false and falls through to the full suite, so a directory nobody thought to enumerate defaults to running everything.

## Verification

Three real runs on a throwaway branch, `sehkone/issue-832-probe`.

| Case | Expected | Result |
|---|---|---|
| Docs-only push, valid base | heavy jobs skipped | [run 30862389565](https://github.com/aicers/review-database/actions/runs/30862389565) — `check` `test` `coverage` **skipped**; `Markdown` and `CI Gate` **success** |
| New branch, base is all-zeros | full suite | [run 30862386939](https://github.com/aicers/review-database/actions/runs/30862386939) — filter logged `Push base missing or unreachable; running the full suite.`, every gated job started (cancelled by hand once observed, to give the runners back) |
| Code change | full suite | this pull request — it touches `.github/workflows/**`, and the checks below are the whole matrix |

The docs-only case above is a `push` event. The `pull_request` path through the same filter is exercised by this pull request itself, which classifies correctly as code.

`actionlint` (with shellcheck) is clean on the result.

## Not in scope

- The duplicate `push`/`pull_request` runs — every job still runs twice per pull request because the trigger is a bare `on: [push, pull_request]`. Worth a separate issue.
- Action version bumps.
- `docs/rfcs/`.

`sehkone/issue-832-probe` is a verification artifact and will be deleted; it is not for merge.

## Follow-up required immediately after merge (repository admin)

Branch protection on `main` currently requires the expanded matrix contexts:

- `check`
- `test (ubuntu-latest)`
- `test (macOS-latest)`

The two `test (...)` contexts are not reported on a docs-only run — a matrix job skipped at the job level is never expanded, so the run reports a bare `test` instead. They must be replaced — once — with the two contexts that always report:

- `CI Gate`
- `Markdown`

**Merge first, then change protection.** Doing it the other way round blocks every pull request, this one included, waiting for a `CI Gate` that does not exist on `main` yet. This pull request itself touches `.github/workflows/**`, so it is a code change, runs the full matrix, and satisfies the current contexts as they stand.
