### PR TITLE
Stop running CI twice on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,19 @@
 
 name: CI
 
-on: [push, pull_request]
+# TRIGGERS: `push` is scoped to `main`. Without a branch filter it also matches
+# pushes to pull-request branches, which already match `pull_request`, so every
+# job ran twice per commit, on two separate workflow runs. Naming `branches:`
+# also stops tag pushes from matching. `pull_request` checks out the branch
+# already merged into its base, so merge coverage is not what is being dropped
+# here — the one thing lost is CI on a branch with no pull request open, and
+# `workflow_dispatch` replaces it (`gh workflow run ci.yml --ref <branch>`).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Closes #834.

Every pull request ran the whole CI workflow **twice** — same commit, two events. On #833 the head commit carried two CI runs and 16 check runs.

## What changed

`.github/workflows/ci.yml`, trigger block only:

```yaml
on:
  pull_request:
  push:
    branches: [main]
  workflow_dispatch:
```

- **`push: branches: [main]`** — merges into `main` still run. The redundant pull-request-branch copy is what goes away.

**Tag pushes go away too.** This workflow had no `branches:` key at all, which is broader than `"**"` — it matched tag pushes as well, so a release ran CI a third time on the tag against the commit `main` had just been tested on.
- **`pull_request:` unfiltered** — a pull request against any base now gets CI, not only those targeting `main`. `aicers/aimer-web`, `aicers/review-protocol` and `aicers/review-database` already used this bare form.
- **`workflow_dispatch:`** — replaces the one thing lost, below.

## What this gives up

A branch with **no open pull request** no longer gets CI automatically. That is the whole cost.

Not lost: `pull_request` checks out `refs/pull/N/merge` — the branch already merged into its base — so merge-result coverage is unaffected, and pushes to `main` are still covered.

Replacements, in order of directness: `gh workflow run ci.yml --ref <branch>` (available once this is on `main`, since `workflow_dispatch` has to be registered from the default branch); opening the pull request as a **draft**, which fires `pull_request` `opened` — nothing in this workflow filters drafts; or running the checks locally.

## Verification

| Case | Expected | Result |
|---|---|---|
| Push this branch | **no** run — the pushed ref's own `ci.yml` no longer matches `push` | ✅ 0 runs on the head commit after push |
| Open this pull request | exactly **one** CI run | see the checks below — one run, where #833 had two |
| Merge to `main` | CI still runs | to be recorded after merge |

Prior art: `aicers/bootler`, `aicers/aimer-web` and `aicers/cluml-home` already scope `push` to the default branch; bootler documents the reasoning in its `ci.yml` header.

`actionlint` (with shellcheck) is clean on the result.

## Out of scope

- Path filtering for documentation-only changes, and markdownlint coverage — separate issues.
- Every other workflow file in this repository.
