### PR TITLE
Update markdownlint-cli2-action to v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@v24
         with:
           # Recursive, deliberately. The action's default glob is
           # `*.{md,markdown}` — repository root only — and this repository's


### PR DESCRIPTION
Closes #838

Bumps the Markdown linter from `@v23` to `@v24`, the current release, which bundles markdownlint 0.41.1. Configuration and globs are unchanged.

Four different tags of this action are in use across the organisation, so the same document can pass in one repository and fail in another. MD056 (table column count), added since the older tags, catches a real defect class: a `|` inside a code span splits a table cell and the data disappears from the rendered table.

**Verification**: markdownlint-cli2 0.23.2 against this branch with the repository's own configuration and CI globs — 5 files linted, `0 issues`, exit 0.