### PR TITLE
Reduce the markdownlint config to the baseline

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,6 +1,3 @@
 ---
-MD004:
-  style: "consistent"
-
 MD024:
   siblings_only: true


### PR DESCRIPTION
Closes #840

`MD004: {style: consistent}` restates MD004's own default, so it constrained nothing. Verified with markdownlint-cli2 0.23.2 (markdownlint 0.41.1) — the version the runner and `markdownlint-cli2-action@v24` both ship: with an empty config a file mixing `-` and `*` bullets is flagged (`MD004/ul-style Expected: dash; Actual: asterisk`) and a file using one style throughout passes, which is exactly what the entry asked for.

The root config now carries `MD024: {siblings_only: true}` and nothing else. This is the organisation-wide direction: the root config holds the shared baseline, and a genuine exception goes in the file that needs it rather than widening the root.

**Verification**: linted with the workflow's own glob before and after — finding count unchanged (0 → 0).
