### PR TITLE
Set the classifier temp file's mode and flush it before rename (#844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Classifier files are now created requesting owner-only permissions (`0o600`)
+  instead of the previous `0o666` reduced by the umask. The umask still applies,
+  so the resulting mode is not fixed, but no group or other bit is ever granted.
+  Under the common `umask 022`, for example, a stored classifier that used to be
+  `0o644` is now `0o600`, so anything reading these files as another account
+  stops working.
 - **BREAKING**: Event timestamps now use `jiff::Timestamp` instead of chrono's
   `DateTime<Utc>`. Existing databases need no migration, because timestamps are
   still stored as `i64` epoch nanoseconds.

--- a/src/classifier_fs.rs
+++ b/src/classifier_fs.rs
@@ -1,5 +1,7 @@
 use std::{
-    fs,
+    fs::{self, OpenOptions},
+    io::Write,
+    os::unix::fs::OpenOptionsExt,
     path::{Path, PathBuf},
 };
 
@@ -81,9 +83,32 @@ impl ClassifierFileManager {
         let timestamp = chrono::Utc::now().timestamp_millis();
         let temp_path = file_path.with_extension(timestamp.to_string());
 
-        // Write to temporary file first
-        fs::write(&temp_path, data)
+        // Write to temporary file first. The mode is requested here because
+        // `rename` installs this inode at the destination, so the finished file
+        // ends up with whatever mode the temporary was created with. `0o600`
+        // records that the destination holds model data this service writes and
+        // reads back under a single account, so nothing else has a reason to
+        // open it; a umask may narrow it further. `create_new` is required for
+        // the mode to take effect, since it is applied only when `open` creates
+        // the file: reopening an existing temporary would keep its old mode.
+        let mut temp_file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temp_path)
             .map_err(|err| ClassifierFsError::FileWrite(err, temp_path.clone()))?;
+        temp_file
+            .write_all(data)
+            .map_err(|err| ClassifierFsError::FileWrite(err, temp_path.clone()))?;
+
+        // Flush before the rename. `upsert_model` has already committed the
+        // model row to RocksDB, and `load_model_by_name` reads this file back
+        // for that row, so a rename reaching disk ahead of the data would leave
+        // the model pointing at an empty or truncated classifier.
+        temp_file
+            .sync_all()
+            .map_err(|err| ClassifierFsError::FileWrite(err, temp_path.clone()))?;
+        drop(temp_file);
 
         // Rename to final location
         if let Err(rename_err) = fs::rename(&temp_path, &file_path) {
@@ -210,7 +235,7 @@ pub enum ClassifierFsError {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{os::unix::fs::PermissionsExt, sync::Arc};
 
     use tempfile::TempDir;
 
@@ -271,6 +296,65 @@ mod tests {
 
         let loaded_data = manager.load_classifier(model_id, name).unwrap();
         assert_eq!(loaded_data, test_data);
+    }
+
+    #[test]
+    fn test_store_grants_no_group_or_other_access() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = ClassifierFileManager::new(temp_dir.path()).unwrap();
+
+        let model_id = 457;
+        let name = "permission_test";
+
+        manager
+            .store_classifier(model_id, name, b"test classifier data")
+            .unwrap();
+
+        let path = manager.create_classifier_path(model_id, name).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode();
+
+        // Only the absence of group and other bits is asserted: a umask can
+        // clear bits but never add them, so this holds whatever the umask is,
+        // while the exact mode does not.
+        assert_eq!(mode & 0o077, 0, "unexpected mode {mode:o} for {path:?}");
+    }
+
+    #[test]
+    fn test_store_replaces_a_group_readable_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = ClassifierFileManager::new(temp_dir.path()).unwrap();
+
+        let model_id = 458;
+        let name = "replacement_test";
+
+        // Stand in for a classifier left by an earlier release, which wrote
+        // through `fs::write` and so ended up group- and other-readable.
+        let path = manager.create_classifier_path(model_id, name).unwrap();
+        let parent = path.parent().unwrap();
+        fs::create_dir_all(parent).unwrap();
+        fs::write(&path, b"stale data").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        manager
+            .store_classifier(model_id, name, b"fresh data")
+            .unwrap();
+
+        // The rename installs the temporary's inode, so the destination takes
+        // the temporary's mode rather than keeping the one it had.
+        let mode = fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o077, 0, "unexpected mode {mode:o} for {path:?}");
+        assert_eq!(
+            manager.load_classifier(model_id, name).unwrap(),
+            b"fresh data"
+        );
+
+        // The rename consumed the temporary, so the classifier is the only
+        // file left in the model directory.
+        let leftovers: Vec<_> = fs::read_dir(parent)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        assert_eq!(leftovers, vec![path]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #844

## Summary

`ClassifierFileManager::store_classifier` wrote its sibling temporary through `fs::write` and renamed it into place without flushing. Two consequences, both fixed here:

- **Permissions.** `fs::write` asks for `0o666` and lets the umask subtract. Because `rename` installs the temporary's inode at the destination, the finished classifier ended up with whatever the umask left — commonly `0o644` — and any mode an operator had set by hand was discarded at the next update. The temporary is now created through `OpenOptions` with `.mode(0o600).write(true).create_new(true)`. `create_new` is load-bearing: a requested mode applies only when `open` actually creates the file, so reopening an existing temporary would silently keep its old mode. The mode is set at creation and never afterwards — no `set_permissions` call, so a deployment under a more restrictive umask still narrows its own files further.
- **Durability.** `sync_all` now runs on the temporary before the rename. `upsert_model` commits the model row to RocksDB first and `load_model_by_name` reads the file back for that row, so a rename reaching disk ahead of the data blocks left the database listing a model whose classifier is absent or zero-length — and a truncated file satisfies `classifier_exists` and is returned by `load_classifier` with no error.

Both open/write and `sync_all` failures are reported as the existing `ClassifierFsError::FileWrite(err, temp_path)`. The rename, the cleanup-on-rename-failure branch, and the `ClassifierFsError` variants are unchanged, and no dependency was added. `.mode()` is called without a `cfg` guard, per the issue: `OpenOptionsExt` is Unix-only and CI builds on `ubuntu-latest` and `macOS-latest`.

Comments at the site record why `0o600` (model data this service writes and reads back under one account) and what the flush protects. The permissions comment notes that a umask may narrow the mode further, rather than claiming it is fixed.

`CHANGELOG.md` gains a `### Changed` entry under `## [Unreleased]`, since an operator can observe the shift; it gives `0o644` → `0o600` as a worked example explicitly labelled as `umask 022` and states that the umask still applies. The flush gets no entry.

## Test plan

- [x] New `test_store_grants_no_group_or_other_access` stores under a `TempDir` and asserts `mode() & 0o077 == 0` — sound under any umask
- [x] Neither new test asserts exact equality with `0o600`, since a restrictive umask legitimately yields `0o400`
- [x] Neither new test reads or sets the umask, and neither mutates the process environment
- [x] New `test_store_replaces_a_group_readable_file` seeds a `0o644` destination, stores over it, and asserts `& 0o077 == 0`, that the fresh bytes read back, and that no temporary is left in the model directory
- [x] `test_store_and_load_classifier`, `test_store_creates_parent_directories`, and `test_concurrent_stores` pass unchanged
- [x] `cargo fmt -- --check --config group_imports=StdExternalCrate` clean
- [x] `cargo clippy --bins --tests --all-features -- -D warnings` clean
- [x] `cargo test --all-features` passes locally on macOS (507 passed, 0 failed); Linux covered by CI
- [x] `markdownlint-cli2 CHANGELOG.md` clean
