### PR TITLE
Update shared instruction blocks to 0.2.1

### DIFF
--- a/.agents/instructions.toml
+++ b/.agents/instructions.toml
@@ -2,5 +2,5 @@
 # it is on, and the shared blocks it has. Its drift check reads this file,
 # and its apply job rewrites it. Which blocks a repository should carry is
 # decided upstream in repos.json, not here.
-ref = "0.1.5"
-blocks = ["workflow", "rust", "changelog"]
+ref = "0.2.0"
+blocks = ["workflow", "agentcoop", "rust", "changelog"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,34 @@ before generating code.
   descriptions or issue comments.
 <!-- END shared:workflow -->
 
+<!-- BEGIN shared:agentcoop -->
+## AgentCoop
+
+AgentCoop is the pipeline this organization runs over its GitHub issues,
+so its vocabulary turns up in issue bodies and pull request comments
+here — and an agent working in this repository may itself be running
+inside it.
+
+- Two agents do the work. The **author** (Agent A) produces, the
+  **reviewer** (Agent B) reviews independently, and the two converge
+  through structured feedback; a deadlock escalates to a human rather
+  than resolving silently. They are usually different models.
+- **Implementation** turns one issue into a pull request with green CI.
+  The author implements it in a dedicated worktree, self-checks, opens
+  the pull request, and drives CI to green; the reviewer then reviews
+  the pushed branch and the two iterate in the pull request's comment
+  thread, tagged `[Author Round N]` and `[Reviewer Round N]`, until it
+  is approved.
+- **Design** shapes work into issues: an RFC file becomes an umbrella
+  issue over a sub-issue tree, or a single issue is refined — and split
+  only when one pull request cannot cover it.
+- **Verification** holds a completed issue against the diffs that closed
+  it and files follow-up sub-issues for whatever it did not deliver.
+- The issue is the contract, and the only input a run is given. A human
+  writes that seed and merges the result; AgentCoop invents no
+  requirement and asks no clarifying question along the way.
+<!-- END shared:agentcoop -->
+
 <!-- BEGIN shared:rust -->
 ## Coding standards (Rust)
 


### PR DESCRIPTION
Synced from `aicers/agent-instructions` at 0.2.1.

Blocks in this pull request: workflow agentcoop rust changelog

0.2.0 added the `agentcoop` block — what AgentCoop is, its author and reviewer agents, and what its implementation, design, and verification stages do. That vocabulary is already in this repository's issues and pull request comments, and AgentCoop injects no instructions of its own, so `AGENTS.md` is the only place it can reach a run. 0.2.1 reworded the block's opening sentence; nothing consumed 0.2.0, so this pull request was rebuilt on it rather than opened a second time.

A new block needs its marker pair placed by hand: nothing upstream can decide where in `AGENTS.md` a block belongs, and the apply refuses the repository until the pair is there. The pair sits after the `workflow` block — the system that turns an issue into a pull request reads next to the issue and pull request conventions — and the apply filled it in the same commit. Splitting the two would have left the drift check red in between, since it rejects a marker the pin file does not list.

The marked blocks are generated. Change the wording upstream in `aicers/agent-instructions` rather than editing it here — the drift check in CI will fail if this repository's copy diverges.